### PR TITLE
Reorder parsing of --configdir switch

### DIFF
--- a/shipyard.py
+++ b/shipyard.py
@@ -2212,17 +2212,17 @@ def main():
     args = parseargs()
     args.action = args.action.lower()
 
-    if args.credentials is None:
-        raise ValueError('credentials json not specified')
-    if args.config is None:
-        raise ValueError('config json not specified')
-
     if args.configdir is not None:
         if args.credentials is None:
             args.credentials = str(pathlib.Path(
                 args.configdir, 'credentials.json'))
         if args.config is None:
             args.config = str(pathlib.Path(args.configdir, 'config.json'))
+
+    if args.credentials is None:
+        raise ValueError('credentials json not specified')
+    if args.config is None:
+        raise ValueError('config json not specified')
 
     with open(args.credentials, 'r') as f:
         config = json.load(f)

--- a/shipyard.py
+++ b/shipyard.py
@@ -2218,6 +2218,8 @@ def main():
                 args.configdir, 'credentials.json'))
         if args.config is None:
             args.config = str(pathlib.Path(args.configdir, 'config.json'))
+        if args.pool is None:
+            args.pool = str(pathlib.Path(args.configdir, 'pool.json'))
 
     if args.credentials is None:
         raise ValueError('credentials json not specified')


### PR DESCRIPTION
As is, if the user supplies the --configdir switch only, they'll get an error because args.credentials is None.

My understanding of the intended usage is that --configdir should be processed first to populate args.credentials and args.config before ensuring that those two values are set.