### PR TITLE
Fix ssh_public_key typo when using Windows

### DIFF
--- a/convoy/fleet.py
+++ b/convoy/fleet.py
@@ -1015,7 +1015,7 @@ def _adjust_settings_for_pool_creation(config):
         pass
     # adjust settings on windows
     if util.on_windows():
-        if pool.ssh.ssh_pub_key is None:
+        if pool.ssh.ssh_public_key is None:
             logger.warning(
                 'disabling ssh user creation due to script being run '
                 'from Windows and no public key is specified')


### PR DESCRIPTION
Fix typo in a Windows check of the SSH properties.
fleet.py was looking for ssh_pub_key, but in settings.py, the value is assigned to ssh_public_key