### PR TITLE
Remove extra azure.mgmt import

### DIFF
--- a/convoy/keyvault.py
+++ b/convoy/keyvault.py
@@ -37,7 +37,6 @@ import zlib
 import adal
 import azure.common.credentials
 import azure.keyvault
-import azure.mgmt.resource.resources
 import msrestazure.azure_active_directory
 # local imports
 from . import settings


### PR DESCRIPTION
This PR removes the unneeded `azure.mgmt` import which was causing missing ImportErrors when trying to run shipyard.