### PR TITLE
Check if jobs.json provides only job environment variables

### DIFF
--- a/convoy/batch.py
+++ b/convoy/batch.py
@@ -1737,7 +1737,7 @@ def add_jobs(
             # merge job env vars into task env vars
             if job_env_vars is None:
                 env_vars = task.environment_variables
-            elif job_env_vars is not None and task.environment_variables is None:
+            elif task.environment_variables is None:
                 env_vars = job_env_vars
             else:
                 env_vars = util.merge_dict(

--- a/convoy/batch.py
+++ b/convoy/batch.py
@@ -1737,6 +1737,8 @@ def add_jobs(
             # merge job env vars into task env vars
             if job_env_vars is None:
                 env_vars = task.environment_variables
+            elif job_env_vars is not None and task.environment_variables is None:
+                env_vars = job_env_vars
             else:
                 env_vars = util.merge_dict(
                     job_env_vars, task.environment_variables)


### PR DESCRIPTION
This PR fixes an edge case where the user provides job-specific environment variables in `jobs.json`, but not task-specific variables, as shown in #16.
