### PR TITLE
Removing non-existent import

### DIFF
--- a/convoy/keyvault.py
+++ b/convoy/keyvault.py
@@ -37,7 +37,6 @@ import zlib
 import adal
 import azure.common.credentials
 import azure.keyvault
-import azure.mgmt.resource.resources
 import msrestazure.azure_active_directory
 # local imports
 from . import settings


### PR DESCRIPTION
The most recent version of shipyard doesn't work on my osx, unless I remove this line. It doesn't seem to be used anywhere in the file.