### PR TITLE
Add max_task_retry_count to job and task definitions

### DIFF
--- a/config_templates/jobs.json
+++ b/config_templates/jobs.json
@@ -7,6 +7,7 @@
                 "abc": "xyz"
             },
             "environment_variables_secret_id": "https://myvault.vault.azure.net/secrets/myjobenv",
+            "max_task_retry_count": 1,
             "input_data": {
                 "azure_batch": [
                     {
@@ -95,6 +96,7 @@
                     "depends_on_range": [
                         1, 10
                     ],
+                    "max_task_retry_count": 1,
                     "multi_instance": {
                         "num_instances": "pool_current_dedicated",
                         "coordination_command": null,

--- a/config_templates/jobs.json
+++ b/config_templates/jobs.json
@@ -7,7 +7,7 @@
                 "abc": "xyz"
             },
             "environment_variables_secret_id": "https://myvault.vault.azure.net/secrets/myjobenv",
-            "max_task_retry_count": 1,
+            "max_task_retries": 1,
             "input_data": {
                 "azure_batch": [
                     {
@@ -96,7 +96,7 @@
                     "depends_on_range": [
                         1, 10
                     ],
-                    "max_task_retry_count": 1,
+                    "max_task_retries": 1,
                     "multi_instance": {
                         "num_instances": "pool_current_dedicated",
                         "coordination_command": null,

--- a/convoy/batch.py
+++ b/convoy/batch.py
@@ -1647,6 +1647,13 @@ def add_jobs(
         del addlcmds
         jpcmdline = util.wrap_commands_in_shell(jpcmd)
         del jpcmd
+        # define max task retry count constraint for this task if set
+        max_task_retry_count = settings.job_max_task_retry_count(jobspec)
+        if max_task_retry_count is not None:
+            job_constraints = batchmodels.JobConstraints(
+                max_task_retry_count=max_task_retry_count
+            )
+        # create job
         job = batchmodels.JobAddParameter(
             id=settings.job_id(jobspec),
             pool_info=batchmodels.PoolInformation(pool_id=pool.id),
@@ -1657,6 +1664,7 @@ def add_jobs(
                 rerun_on_node_reboot_after_success=False,
             ),
             uses_task_dependencies=False,
+            constraints=job_constraints,
         )
         lastjob = job.id
         # perform checks:
@@ -1840,6 +1848,11 @@ def add_jobs(
             if addlcmds is not None:
                 task_commands.append(addlcmds)
             del addlcmds
+            # define max task retry count constraint for this task if set
+            if task.max_task_retry_count is not None:
+                task_constraints = batchmodels.TaskConstraints(
+                    max_task_retry_count=task.max_task_retry_count
+                )
             # create task
             batchtask = batchmodels.TaskAddParameter(
                 id=task.id,
@@ -1847,6 +1860,7 @@ def add_jobs(
                 run_elevated=True,
                 resource_files=[],
                 multi_instance_settings=mis,
+                constraints=task_constraints,
             )
             # add envfile
             if sas_urls is not None:

--- a/convoy/batch.py
+++ b/convoy/batch.py
@@ -1648,6 +1648,7 @@ def add_jobs(
         jpcmdline = util.wrap_commands_in_shell(jpcmd)
         del jpcmd
         # define max task retry count constraint for this task if set
+        job_constraints = None
         max_task_retry_count = settings.job_max_task_retry_count(jobspec)
         if max_task_retry_count is not None:
             job_constraints = batchmodels.JobConstraints(
@@ -1849,6 +1850,7 @@ def add_jobs(
                 task_commands.append(addlcmds)
             del addlcmds
             # define max task retry count constraint for this task if set
+            task_constraints = None
             if task.max_task_retry_count is not None:
                 task_constraints = batchmodels.TaskConstraints(
                     max_task_retry_count=task.max_task_retry_count

--- a/convoy/batch.py
+++ b/convoy/batch.py
@@ -1649,10 +1649,10 @@ def add_jobs(
         del jpcmd
         # define max task retry count constraint for this task if set
         job_constraints = None
-        max_task_retry_count = settings.job_max_task_retry_count(jobspec)
-        if max_task_retry_count is not None:
+        max_task_retries = settings.job_max_task_retries(jobspec)
+        if max_task_retries is not None:
             job_constraints = batchmodels.JobConstraints(
-                max_task_retry_count=max_task_retry_count
+                max_task_retry_count=max_task_retries
             )
         # create job
         job = batchmodels.JobAddParameter(
@@ -1851,9 +1851,9 @@ def add_jobs(
             del addlcmds
             # define max task retry count constraint for this task if set
             task_constraints = None
-            if task.max_task_retry_count is not None:
+            if task.max_task_retries is not None:
                 task_constraints = batchmodels.TaskConstraints(
-                    max_task_retry_count=task.max_task_retry_count
+                    max_task_retry_count=task.max_task_retries
                 )
             # create task
             batchtask = batchmodels.TaskAddParameter(

--- a/convoy/settings.py
+++ b/convoy/settings.py
@@ -134,7 +134,8 @@ TaskSettings = collections.namedtuple(
         'id', 'image', 'name', 'docker_run_options', 'environment_variables',
         'environment_variables_secret_id', 'envfile', 'resource_files',
         'command', 'infiniband', 'gpu', 'depends_on', 'depends_on_range',
-        'docker_run_cmd', 'docker_exec_cmd', 'multi_instance', 'max_task_retry_count',
+        'docker_run_cmd', 'docker_exec_cmd', 'multi_instance',
+        'max_task_retry_count',
     ]
 )
 MultiInstanceSettings = collections.namedtuple(
@@ -1624,7 +1625,7 @@ def job_max_task_retry_count(conf):
     """
     try:
         max_task_retry_count = int(conf['max_task_retry_count'])
-        if util.is_none_or_empty(max_task_retry_count):
+        if max_task_retry_count is None:
             raise KeyError()
     except KeyError:
         max_task_retry_count = None
@@ -2040,7 +2041,7 @@ def task_settings(pool, config, conf):
     # max_task_retry_count
     try:
         max_task_retry_count = int(conf['max_task_retry_count'])
-        if util.is_none_or_empty(max_task_retry_count):
+        if max_task_retry_count is None:
             raise KeyError()
     except KeyError:
         max_task_retry_count = None

--- a/convoy/settings.py
+++ b/convoy/settings.py
@@ -135,7 +135,7 @@ TaskSettings = collections.namedtuple(
         'environment_variables_secret_id', 'envfile', 'resource_files',
         'command', 'infiniband', 'gpu', 'depends_on', 'depends_on_range',
         'docker_run_cmd', 'docker_exec_cmd', 'multi_instance',
-        'max_task_retry_count',
+        'max_task_retries',
     ]
 )
 MultiInstanceSettings = collections.namedtuple(
@@ -1616,7 +1616,7 @@ def job_environment_variables_secret_id(conf):
     return secid
 
 
-def job_max_task_retry_count(conf):
+def job_max_task_retries(conf):
     # type: (dict) -> int
     """Get number of times a task should be retried in a particular job
     :param dict conf: job configuration object
@@ -1624,12 +1624,12 @@ def job_max_task_retry_count(conf):
     :return: max task retry count
     """
     try:
-        max_task_retry_count = int(conf['max_task_retry_count'])
-        if max_task_retry_count is None:
+        max_task_retries = conf['max_task_retries']
+        if max_task_retries is None:
             raise KeyError()
     except KeyError:
-        max_task_retry_count = None
-    return max_task_retry_count
+        max_task_retries = None
+    return max_task_retries
 
 
 def has_depends_on_task(conf):
@@ -2038,13 +2038,13 @@ def task_settings(pool, config, conf):
         num_instances = 0
         cc_args = None
         mi_resource_files = None
-    # max_task_retry_count
+    # max_task_retries
     try:
-        max_task_retry_count = int(conf['max_task_retry_count'])
-        if max_task_retry_count is None:
+        max_task_retries = conf['max_task_retries']
+        if max_task_retries is None:
             raise KeyError()
     except KeyError:
-        max_task_retry_count = None
+        max_task_retries = None
     return TaskSettings(
         id=task_id,
         image=image,
@@ -2066,5 +2066,5 @@ def task_settings(pool, config, conf):
             coordination_command=cc_args,
             resource_files=mi_resource_files,
         ),
-        max_task_retry_count=max_task_retry_count,
+        max_task_retries=max_task_retries,
     )

--- a/convoy/settings.py
+++ b/convoy/settings.py
@@ -134,7 +134,7 @@ TaskSettings = collections.namedtuple(
         'id', 'image', 'name', 'docker_run_options', 'environment_variables',
         'environment_variables_secret_id', 'envfile', 'resource_files',
         'command', 'infiniband', 'gpu', 'depends_on', 'depends_on_range',
-        'docker_run_cmd', 'docker_exec_cmd', 'multi_instance',
+        'docker_run_cmd', 'docker_exec_cmd', 'multi_instance', 'max_task_retry_count',
     ]
 )
 MultiInstanceSettings = collections.namedtuple(
@@ -1615,6 +1615,22 @@ def job_environment_variables_secret_id(conf):
     return secid
 
 
+def job_max_task_retry_count(conf):
+    # type: (dict) -> int
+    """Get number of times a task should be retried in a particular job
+    :param dict conf: job configuration object
+    :rtype: int
+    :return: max task retry count
+    """
+    try:
+        max_task_retry_count = int(conf['max_task_retry_count'])
+        if util.is_none_or_empty(max_task_retry_count):
+            raise KeyError()
+    except KeyError:
+        max_task_retry_count = None
+    return max_task_retry_count
+
+
 def has_depends_on_task(conf):
     # type: (dict) -> bool
     """Determines if task has task dependencies
@@ -2021,6 +2037,13 @@ def task_settings(pool, config, conf):
         num_instances = 0
         cc_args = None
         mi_resource_files = None
+    # max_task_retry_count
+    try:
+        max_task_retry_count = int(conf['max_task_retry_count'])
+        if util.is_none_or_empty(max_task_retry_count):
+            raise KeyError()
+    except KeyError:
+        max_task_retry_count = None
     return TaskSettings(
         id=task_id,
         image=image,
@@ -2042,4 +2065,5 @@ def task_settings(pool, config, conf):
             coordination_command=cc_args,
             resource_files=mi_resource_files,
         ),
+        max_task_retry_count=max_task_retry_count,
     )

--- a/docs/10-batch-shipyard-configuration.md
+++ b/docs/10-batch-shipyard-configuration.md
@@ -724,7 +724,7 @@ The jobs schema is as follows:
                 "abc": "xyz"
             },
             "environment_variables_secret_id": "https://myvault.vault.azure.net/secrets/myjobenv",
-            "max_task_retry_count": 3,
+            "max_task_retries": 3,
             "input_data": {
                 "azure_batch": [
                     {
@@ -813,7 +813,7 @@ The jobs schema is as follows:
                     ],
                     "infiniband": false,
                     "gpu": false,
-                    "max_task_retry_count": 3,
+                    "max_task_retries": 3,
                     "multi_instance": {
                         "num_instances": "pool_current_dedicated",
                         "coordination_command": null,
@@ -851,9 +851,9 @@ environment variables to be expanded.
 variables stored in KeyVault that should be applied to all tasks operating
 under the job. The secret stored in KeyVault must be a valid json string,
 e.g., `{ "env_var_name": "env_var_value" }`.
-* (optional) `max_task_retry_count` sets the maximum number of times that
+* (optional) `max_task_retries` sets the maximum number of times that
 Azure Batch should retry all tasks in this job for. By default, Azure Batch
-does not retry tasks that fail (i.e. `max_task_retry_count` is 0).
+does not retry tasks that fail (i.e. `max_task_retries` is 0).
 * (optional) `input_data` is an object containing data that should be
 ingressed for the job. Any `input_data` defined at this level will be
 downloaded for this job which can be run on any number of compute nodes
@@ -1019,10 +1019,10 @@ transferred again. This object currently supports `azure_batch` and
   * (optional) `gpu` designates if this container requires access to the GPU
     devices on the host. If this property is set to `true`, Docker containers
     are instantiated via `nvidia-docker`. This requires N-series VM instances.
-  * (optional) `max_task_retry_count` sets the maximum number of times that
+  * (optional) `max_task_retries` sets the maximum number of times that
     Azure Batch should retry this task for. This overrides the job-level task
     retry count. By default, Azure Batch does not retry tasks that fail
-    (i.e. `max_task_retry_count` is 0).
+    (i.e. `max_task_retries` is 0).
   * (optional) `multi_instance` is a property indicating that this task is a
     multi-instance task. This is required if the Docker image is an MPI
     program. Additional information about multi-instance tasks and Batch

--- a/docs/10-batch-shipyard-configuration.md
+++ b/docs/10-batch-shipyard-configuration.md
@@ -724,6 +724,7 @@ The jobs schema is as follows:
                 "abc": "xyz"
             },
             "environment_variables_secret_id": "https://myvault.vault.azure.net/secrets/myjobenv",
+            "max_task_retry_count": 3,
             "input_data": {
                 "azure_batch": [
                     {
@@ -812,6 +813,7 @@ The jobs schema is as follows:
                     ],
                     "infiniband": false,
                     "gpu": false,
+                    "max_task_retry_count": 3,
                     "multi_instance": {
                         "num_instances": "pool_current_dedicated",
                         "coordination_command": null,
@@ -849,6 +851,9 @@ environment variables to be expanded.
 variables stored in KeyVault that should be applied to all tasks operating
 under the job. The secret stored in KeyVault must be a valid json string,
 e.g., `{ "env_var_name": "env_var_value" }`.
+* (optional) `max_task_retry_count` sets the maximum number of times that
+Azure Batch should retry all tasks in this job for. By default, Azure Batch
+does not retry tasks that fail (i.e. `max_task_retry_count` is 1).
 * (optional) `input_data` is an object containing data that should be
 ingressed for the job. Any `input_data` defined at this level will be
 downloaded for this job which can be run on any number of compute nodes
@@ -1014,6 +1019,10 @@ transferred again. This object currently supports `azure_batch` and
   * (optional) `gpu` designates if this container requires access to the GPU
     devices on the host. If this property is set to `true`, Docker containers
     are instantiated via `nvidia-docker`. This requires N-series VM instances.
+  * (optional) `max_task_retry_count` sets the maximum number of times that
+    Azure Batch should retry this task for. This overrides the job-level task
+    retry count. By default, Azure Batch does not retry tasks that fail
+    (i.e. `max_task_retry_count` is 1).
   * (optional) `multi_instance` is a property indicating that this task is a
     multi-instance task. This is required if the Docker image is an MPI
     program. Additional information about multi-instance tasks and Batch

--- a/docs/10-batch-shipyard-configuration.md
+++ b/docs/10-batch-shipyard-configuration.md
@@ -853,7 +853,7 @@ under the job. The secret stored in KeyVault must be a valid json string,
 e.g., `{ "env_var_name": "env_var_value" }`.
 * (optional) `max_task_retry_count` sets the maximum number of times that
 Azure Batch should retry all tasks in this job for. By default, Azure Batch
-does not retry tasks that fail (i.e. `max_task_retry_count` is 1).
+does not retry tasks that fail (i.e. `max_task_retry_count` is 0).
 * (optional) `input_data` is an object containing data that should be
 ingressed for the job. Any `input_data` defined at this level will be
 downloaded for this job which can be run on any number of compute nodes
@@ -1022,7 +1022,7 @@ transferred again. This object currently supports `azure_batch` and
   * (optional) `max_task_retry_count` sets the maximum number of times that
     Azure Batch should retry this task for. This overrides the job-level task
     retry count. By default, Azure Batch does not retry tasks that fail
-    (i.e. `max_task_retry_count` is 1).
+    (i.e. `max_task_retry_count` is 0).
   * (optional) `multi_instance` is a property indicating that this task is a
     multi-instance task. This is required if the Docker image is an MPI
     program. Additional information about multi-instance tasks and Batch


### PR DESCRIPTION
This PR addresses #22 by adding `max_task_retry_count` to the job and task definitions in `jobs.json`. I've also made the relevant changes in the `config_templates/jobs.json` and in the configuration documentation. Tested retries with failing containers, worked as expected.
