### PR TITLE
Fix issue with listtasks failing on active status tasks

### DIFF
--- a/convoy/batch.py
+++ b/convoy/batch.py
@@ -1526,9 +1526,10 @@ def list_tasks(batch_client, config, jobid=None):
                                   task.execution_info.exit_code)
                 else:
                     ei = ''
-                some_extra_info = ('none','none',ei)
+                some_extra_info = ('none', 'none', ei)
                 if task.node_info is not None:
-                    some_extra_info = (task.node_info.pool_id,task.node_info.node_id,ei)
+                    some_extra_info = (task.node_info.pool_id, 
+                            task.node_info.node_id, ei)
                 logger.info(
                     'job_id={} task_id={} [state={} pool_id={} '
                     'node_id={}{}]'.format(

--- a/convoy/batch.py
+++ b/convoy/batch.py
@@ -1528,8 +1528,9 @@ def list_tasks(batch_client, config, jobid=None):
                     ei = ''
                 some_extra_info = ('none', 'none', ei)
                 if task.node_info is not None:
-                    some_extra_info = (task.node_info.pool_id, 
-                            task.node_info.node_id, ei)
+                    some_extra_info = (
+                                task.node_info.pool_id,
+                                task.node_info.node_id, ei)
                 logger.info(
                     'job_id={} task_id={} [state={} pool_id={} '
                     'node_id={}{}]'.format(

--- a/convoy/batch.py
+++ b/convoy/batch.py
@@ -1526,11 +1526,13 @@ def list_tasks(batch_client, config, jobid=None):
                                   task.execution_info.exit_code)
                 else:
                     ei = ''
+                some_extra_info = ('none','none',ei)
+                if task.node_info is not None:
+                    some_extra_info = (task.node_info.pool_id,task.node_info.node_id,ei)
                 logger.info(
                     'job_id={} task_id={} [state={} pool_id={} '
                     'node_id={}{}]'.format(
-                        job_id, task.id, task.state, task.node_info.pool_id,
-                        task.node_info.node_id, ei))
+                        job_id, task.id, task.state, *some_extra_info))
                 i += 1
         except batchmodels.batch_error.BatchErrorException as ex:
             if 'The specified job does not exist' in ex.message.value:


### PR DESCRIPTION
Fix issue with tasks that are not in state completed or running that cause command `jobs listtasks` to fail.

Traceback:
```
Traceback (most recent call last):
  File "/home/adotti/Work/Azure/mycode/batch-shipyard/shipyard.py", line 921, in <module>
    cli()
  File "/home/adotti/.local/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/home/adotti/.local/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/home/adotti/.local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/adotti/.local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/adotti/.local/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/adotti/.local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/adotti/.local/lib/python2.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/home/adotti/.local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/adotti/Work/Azure/mycode/batch-shipyard/shipyard.py", line 761, in jobs_list_tasks
    convoy.fleet.action_jobs_listtasks(ctx.batch_client, ctx.config, jobid)
  File "/home/adotti/Work/Azure/mycode/batch-shipyard/convoy/fleet.py", line 1471, in action_jobs_listtasks
    batch.list_tasks(batch_client, config, jobid)
  File "/home/adotti/Work/Azure/mycode/batch-shipyard/convoy/batch.py", line 1532, in list_tasks
    job_id, task.id, task.state, task.node_info.pool_id,
AttributeError: 'NoneType' object has no attribute 'pool_id'
```