### PR TITLE
Fix ingress data call

### DIFF
--- a/convoy/fleet.py
+++ b/convoy/fleet.py
@@ -738,7 +738,8 @@ def _add_pool(
     storage_threads = []
     if pool_settings.transfer_files_on_pool_creation:
         storage_threads = data.ingress_data(
-            batch_client, config, rls=None, kind='storage')
+            batch_client, compute_client, network_client, config, rls=None,
+            kind='storage')
     # shipyard settings
     bs = settings.batch_shipyard_settings(config)
     # data replication and peer-to-peer settings
@@ -945,8 +946,8 @@ def _add_pool(
     if pool_settings.transfer_files_on_pool_creation:
         _pool = batch_client.pool.get(pool.id)
         data.ingress_data(
-            batch_client, config, rls=rls, kind='shared',
-            current_dedicated=_pool.current_dedicated)
+            batch_client, compute_client, network_client, config, rls=rls,
+            kind='shared', current_dedicated=_pool.current_dedicated)
         del _pool
     # wait for storage ingress processes
     data.wait_for_storage_threads(storage_threads)


### PR DESCRIPTION
Commit `9dc46735309547f7cd19693073c79f4f8e1a1588` has changed `data.ingress_data` signature from `batch_client, config, **kwargs` to `batch_client, compute_client, network_client, config , **kwargs`, but there are still cases of former usage ([[1](https://github.com/Azure/batch-shipyard/blob/5879e485865a643a319cb19f39aaa511ab16b1fb/convoy/fleet.py#L741)] and [[2](https://github.com/Azure/batch-shipyard/blob/5879e485865a643a319cb19f39aaa511ab16b1fb/convoy/fleet.py#L947)])