### PR TITLE
Updated VM size

### DIFF
--- a/recipes/CNTK-GPU-OpenMPI/config/multinode-multigpu/pool.json
+++ b/recipes/CNTK-GPU-OpenMPI/config/multinode-multigpu/pool.json
@@ -1,7 +1,7 @@
 {
     "pool_specification": {
         "id": "cntk-multinode-multigpu",
-        "vm_size": "STANDARD_NC24",
+        "vm_size": "STANDARD_NC6",
         "vm_count": 2,
         "inter_node_communication_enabled": true,
         "publisher": "Canonical",


### PR DESCRIPTION
According to service quotas and limits mentioned [here](https://docs.microsoft.com/en-us/azure/batch/batch-quota-limit), the default limit of cores per batch account is 20. Since we are using `vm_count = 2`, the total core becomes `48` if we use `STANDARD_NC24` VMs. Although quota and limits can be increases, but it is a manual process and one needs to contact Azure support to explain the business case why increased quota may be required. However, using the `STANDARD_NC6` VM with `vm_count = 2` won't exceed the default limit (_assuming one does not have any other pre-existing VMs with more than 8 cores in total_).