### PR TITLE
Avoiding breaking change related to vm_count

### DIFF
--- a/convoy/settings.py
+++ b/convoy/settings.py
@@ -448,6 +448,11 @@ def _pool_vm_count(config):
     :return: pool vm count settings
     """
     conf = pool_specification(config)['vm_count']
+    if isinstance(conf, int):
+        vm_count_spec = {}
+        vm_count_spec['dedicated'] = conf
+        vm_count_spec['low_priority'] = 0
+        conf = vm_count_spec
     return PoolVmCountSettings(
         dedicated=_kv_read(conf, 'dedicated', 0),
         low_priority=_kv_read(conf, 'low_priority', 0),

--- a/docs/13-batch-shipyard-configuration-pool.md
+++ b/docs/13-batch-shipyard-configuration-pool.md
@@ -87,7 +87,9 @@ The `pool_specification` property has the following members:
 [Azure Virtual Machine Instance Size](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/).
 Please note that not all regions have every VM size available.
 * (required) `vm_count` is the number of compute nodes to allocate. You may
-specify a mixed number of compute nodes in the following properties:
+specify a number of dedicated compute nodes to allocate if you only desire
+dedicated nodes and no low-priority nodes. Alternatively, you can supply a
+mixed number of compute nodes in the following properties:
   * (optional) `dedicated` is the number of dedicated compute nodes to
     allocate. These nodes cannot be pre-empted. The default value is `0`.
   * (optional) `low_priority` is the number of low-priority compute nodes to


### PR DESCRIPTION
To my understanding, avoiding the proposed breaking change in [2.7.0b1](https://github.com/Azure/batch-shipyard/releases/tag/2.7.0b1) is relatively simple.

I suggest allowing to either specify a number of dedicated compute nodes or a mixture of dedicated and low-priority nodes.