### PR TITLE
Fix invalid data transfer parameter handling

### DIFF
--- a/convoy/data.py
+++ b/convoy/data.py
@@ -234,7 +234,7 @@ def process_input_data(config, bxfile, spec, on_task=False):
         tfmpre = ''
         tfmpost = ''
     else:
-        bxcmd = 'set -f; $AZ_BATCH_NODE_STARTUP_DIR/wd/{} {{}} set +f'.format(
+        bxcmd = 'set -f; $AZ_BATCH_NODE_STARTUP_DIR/wd/{} {{}}; set +f'.format(
             bxfile[0])
         tfmbind = (
             '-v $AZ_BATCH_NODE_ROOT_DIR:$AZ_BATCH_NODE_ROOT_DIR '
@@ -397,7 +397,7 @@ def process_output_data(config, bxfile, spec):
         bxcmd = ('powershell -ExecutionPolicy Unrestricted -command '
                  '%AZ_BATCH_NODE_STARTUP_DIR%\\wd\\{} {{}}').format(bxfile[0])
     else:
-        bxcmd = 'set -f; $AZ_BATCH_NODE_STARTUP_DIR/wd/{} {{}} set +f'.format(
+        bxcmd = 'set -f; $AZ_BATCH_NODE_STARTUP_DIR/wd/{} {{}}; set +f'.format(
             bxfile[0])
     ret = []
     output_data = settings.output_data(spec)


### PR DESCRIPTION
For the following pool and job, the job preparation doesn't finish and task execution doesn't start. 

Pool:
```YAML
pool_specification:
  id: mypool
  ssh:
    username: emgag
    ssh_public_key: /config/id_rsa_shipyard.pub
    ssh_private_key: /config/id_rsa_shipyard
  vm_configuration:
    platform_image:
      offer: UbuntuServer
      publisher: Canonical
      sku: 16.04-LTS
      native: true
  vm_count:
    dedicated: 1
    low_priority: 0
  vm_size: STANDARD_D1_V2
```

Job:
```YAML
job_specifications:
- id: myjob1
  auto_complete: true
  input_data:
    azure_storage:
      - storage_account_settings: anotherstorageaccount
        remote_path: container1/blubber
        local_path: $AZ_BATCH_JOB_PREP_WORKING_DIR/input
        is_file_share: false
        blobxfer_extra_options: null
  tasks:
  - command: find /mnt/batch/tasks
    docker_image: busybox
```

Output of the jobs:

```
root@31ad4caa1dbf47938bd26cb091780b54000000:~# cat /mnt/batch/tasks/workitems/myjob1/job-1/jobpreparation/stderr.txt 
/mnt/batch/tasks/startup/wd/shipyard_blobxfer.sh: line 15: [: ==: unary operator expected
/mnt/batch/tasks/startup/wd/shipyard_blobxfer.sh: line 39: [: ==: unary operator expected
/mnt/batch/tasks/startup/wd/shipyard_blobxfer.sh: line 44: [: ==: unary operator expected
# cat /mnt/batch/tasks/workitems/myjob1/job-1/jobpreparation/stdout.txt 
DEBUG: Block for Docker images: busybox
DEBUG: Block for Singularity images: 
INFO: blocking until Docker images ready: busybox
INFO: all Docker images present
2017-11-14 15:54:51.979 INFO - 
============================================
         Azure blobxfer parameters
============================================
         blobxfer version: 1.0.0
                 platform: Linux-4.11.0-1014-azure-x86_64-with
               components: CPython=3.6.1 azstor.blob=0.37.1 azstor.file=0.36.0 crypt=2.1.3 req=2.18.4
       transfer direction: Azure -> local
                  workers: disk=2 xfer=4 md5=0 crypto=0
                 log file: None
              resume file: None
                  timeout: connect=3.1 read=12.1
                     mode: StorageModes.Auto
                  skip on: fs_match=False lmt_ge=False md5=False
        delete extraneous: False
                overwrite: True
                recursive: True
            rename single: False
         chunk size bytes: 0
         compute file md5: False
  restore file attributes: False
          rsa private key: None
        local destination: /mnt/batch/tasks/workitems/myjob1/job-1/jobpreparation/wd/input
============================================
2017-11-14 15:54:51.980 INFO - blobxfer start time: 2017-11-14 15:54:51.979915+00:00
2017-11-14 15:54:52.024 DEBUG - dest is_dir=True for 1 specs
2017-11-14 15:54:52.026 INFO - downloading blobs/files to local path: /mnt/batch/tasks/workitems/myjob1/job-1/jobpreparation/wd/input
2017-11-14 15:54:52.026 DEBUG - spawning 4 transfer threads
2017-11-14 15:54:52.073 DEBUG - spawning 2 disk threads
2017-11-14 15:54:52.146 DEBUG - 0 files 0.0000 MiB filesize and/or lmt_ge skipped
2017-11-14 15:54:52.146 DEBUG - 2 remote files processed, waiting for download completion of approx. 0.9691 MiB
2017-11-14 15:54:52.310 INFO - MD5: SKIPPED, container1/blubber/cat-wallpaper-12.jpg None <L..R> P4AoDLEbvGUJt1kgqdXP2w==
2017-11-14 15:54:52.434 INFO - MD5: SKIPPED, container1/blubber/000-video-posting-1200x630.jpg None <L..R> CXZG1w53vlexj2E+vj7TIg==
2017-11-14 15:54:52.435 INFO - attempting to delete 0 extraneous files
2017-11-14 15:54:52.435 INFO - elapsed download + verify time and throughput of 0.0009 GiB: 0.289 sec, 26.8360 Mbps (3.355 MiB/sec)
2017-11-14 15:54:52.435 INFO - blobxfer end time: 2017-11-14 15:54:52.435422+00:00 (elapsed: 0.456 sec)
unknown  transfer
```

The parameters supplied to this script here https://github.com/Azure/batch-shipyard/blob/master/scripts/shipyard_blobxfer.sh#L7  not only contain the storage configuration but also an additional entry `set +f` at the end, which leads to exit 1 and terminating the job preparation.

