### PR TITLE
Fix for the index out of range exception

### DIFF
--- a/convoy/slurm.py
+++ b/convoy/slurm.py
@@ -908,7 +908,7 @@ def create_slurm_controller(
         if util.is_none_or_empty(pips):
             fqdn[i] = None
             ipinfo[i] = 'private_ip_address={}'.format(
-                nics[i].ip_configurations[i].private_ip_address)
+                nics[i].ip_configurations[0].private_ip_address)
         else:
             # refresh public ip for vm
             pip = network_client.public_ip_addresses.get(


### PR DESCRIPTION
while Creating a slurm cluser with the value of false as below 
enable: false 
for the public_ip parameter in the slurm.yml  configuration file
for the login and controller nodes we are getting index out of range exception.
Kindly Review.
Thank You.
### Pull Request Checklist

- [ ] Review the [contributing guidelines](https://github.com/Azure/batch-shipyard/blob/master/CONTRIBUTING.md)
- [ ] Outstanding issue linked, if applicable
- [ ] PR should only be opened against `master` if it includes no features (open against `develop` otherwise)
- [ ] Commit messages should conform to [good style practices](https://chris.beams.io/posts/git-commit/)
- [ ] PR should pass all checks and have no conflicts

### Description
Please describe the pull request.

