### PR TITLE
Changing the APT test logic in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -158,7 +158,7 @@ echo "Detected OS: $DISTRIB_ID $DISTRIB_RELEASE"
 
 # install requisite packages from distro repo
 if [ -n "$SUDO" ] || [ "$(id -u)" -eq 0 ]; then
-    if [ "$DISTRIB_LIKE" == "debian" ]; then
+    if [ "$DISTRIB_ID" == "debian" || "$DISTRIB_LIKE" == "debian" ]; then
         $SUDO apt-get update
         if [ $ANACONDA -eq 1 ]; then
             PYTHON_PKGS=

--- a/install.sh
+++ b/install.sh
@@ -133,6 +133,7 @@ else
         . /etc/os-release
         DISTRIB_ID=$ID
         DISTRIB_RELEASE=$VERSION_ID
+        DISTRIB_LIKE=$ID_LIKE
     fi
     # check for OS X
     if [ -z "${DISTRIB_ID+x}" ] && [ "$(uname)" == "Darwin" ]; then
@@ -157,7 +158,7 @@ echo "Detected OS: $DISTRIB_ID $DISTRIB_RELEASE"
 
 # install requisite packages from distro repo
 if [ -n "$SUDO" ] || [ "$(id -u)" -eq 0 ]; then
-    if [ "$DISTRIB_ID" == "ubuntu" ] || [ "$DISTRIB_ID" == "debian" ]; then
+    if [ "$DISTRIB_LIKE" == "debian" ]; then
         $SUDO apt-get update
         if [ $ANACONDA -eq 1 ]; then
             PYTHON_PKGS=


### PR DESCRIPTION
Changing pre-apt test to use ID_LIKE instead of just ID, potentially enabling installation in more Debian-derived distributions. This is related to #355.

### Pull Request Checklist

- [x] Review the [contributing guidelines](https://github.com/Azure/batch-shipyard/blob/master/CONTRIBUTING.md)
- [x] Outstanding issue linked, if applicable
- [x] PR should only be opened against `master` if it includes no features (open against `develop` otherwise)
- [x] Commit messages should conform to [good style practices](https://chris.beams.io/posts/git-commit/)
- [x] PR should pass all checks and have no conflicts

### Description

This was successfully tested in a Debian-derived distro that has an arbitrary ID but where /etc/os-release also had an ID_LIKE pointing to Debian. It should also be tested in Debian and Ubuntu proper (across all supported releases), noting that Ubuntu uses ID_LIKE as well.
