### PR TITLE
Test python system executable before nodeprep use

### DIFF
--- a/scripts/shipyard_nodeprep.sh
+++ b/scripts/shipyard_nodeprep.sh
@@ -382,7 +382,11 @@ get_vm_size_from_imds() {
         return
     fi
     curl -fSsL -H Metadata:true "http://169.254.169.254/metadata/instance?api-version=${IMDS_VERSION}" > imd.json
-    vm_size=$(python -c "import json;f=open('imd.json','r');a=json.load(f);print(a['compute']['vmSize']).lower()")
+    if command -v python3 > /dev/null 2>&1; then
+        vm_size=$(python3 -c "import json;f=open('imd.json','r');a=json.load(f);print(a['compute']['vmSize'].lower())")
+    else
+        vm_size=$(python -c "import json;f=open('imd.json','r');a=json.load(f);print(a['compute']['vmSize'].lower())")
+    fi
     if [[ "$vm_size" =~ ^standard_(((hb|hc)[0-9]+m?rs?(_v[1-9])?)|(nc[0-9]+rs_v3)|(nd[0-9]+rs_v2))$ ]]; then
         # SR-IOV RDMA
         vm_rdma_type=1


### PR DESCRIPTION
Because of some operating systems choice to deprecate a named system
executable of just python, this will test for a suitable python3 if
available, otherwise revert to the prior standard command

Issues: #363 

### Pull Request Checklist

- [x] Review the [contributing guidelines](https://github.com/Azure/batch-shipyard/blob/master/CONTRIBUTING.md)
- [x] Outstanding issue linked, if applicable
- [x] PR should only be opened against `master` if it includes no features (open against `develop` otherwise)
- [x] Commit messages should conform to [good style practices](https://chris.beams.io/posts/git-commit/)
- [x] PR should pass all checks and have no conflicts

### Description
Amends the python call to point to python3 if available, else defaults to python. Eliminates command not found error
